### PR TITLE
fix: improve index performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,7 @@ dependencies = [
  "capnpc",
  "distrans_fileindex",
  "flume",
+ "hex",
  "path-absolutize",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ version = "0.1.2"
 dependencies = [
  "clap",
  "dirs",
- "distrans_fileindex 0.1.2",
+ "distrans_fileindex",
  "distrans_peer",
  "flume",
  "futures",
@@ -881,17 +881,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "veilid-core",
-]
-
-[[package]]
-name = "distrans_fileindex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d44a4f6104bc047c9fc66e15e1d67524bb49746e48c12ae14ba32d746952828"
-dependencies = [
- "rust-crypto",
- "thiserror",
- "tokio",
 ]
 
 [[package]]
@@ -912,7 +901,7 @@ version = "0.1.2"
 dependencies = [
  "capnp",
  "capnpc",
- "distrans_fileindex 0.1.1",
+ "distrans_fileindex",
  "flume",
  "path-absolutize",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
 name = "distrans_fileindex"
 version = "0.1.2"
 dependencies = [
+ "flume",
  "hex-literal",
  "rust-crypto",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,12 +868,14 @@ name = "distrans"
 version = "0.1.2"
 dependencies = [
  "clap",
- "distrans_fileindex 0.1.1",
- "distrans_peer 0.1.1",
+ "dirs",
+ "distrans_fileindex 0.1.2",
+ "distrans_peer",
  "flume",
  "futures",
  "metrics",
  "metrics-exporter-prometheus",
+ "rust-crypto",
  "tokio",
  "tokio-util",
  "tracing",
@@ -893,24 +904,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "distrans_peer"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e89501f6370da9332f498caa4fafd1373fcb3e00ec27ef4d6a520a5c70a5778"
-dependencies = [
- "capnp",
- "capnpc",
- "distrans_fileindex 0.1.1",
- "flume",
- "path-absolutize",
- "thiserror",
- "tokio",
- "tokio-util",
- "tracing",
- "veilid-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,14 @@ name = "stress"
 
 [dependencies]
 clap = {version = "4.4", features = ["derive", "env"]}
-distrans_fileindex = "0.1"
-distrans_peer = "0.1"
+dirs = "5.0"
+distrans_fileindex = { version = "0.1", path = "distrans-fileindex" }
+distrans_peer = { version = "0.1", path = "distrans-peer" }
 flume = "0.11"
 futures = "0.3"
 metrics = "0.22"
 metrics-exporter-prometheus = { version = "0.13.0", features = ["http-listener"] }
+rust-crypto = "0.2"
 tokio = "1.33"
 tokio-util = "0.7"
 tracing = { version = "0.1", features = ["log", "attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,12 +57,12 @@ name = "stress"
 [dependencies]
 clap = {version = "4.4", features = ["derive", "env"]}
 dirs = "5.0"
-distrans_fileindex = { version = "0.1", path = "distrans-fileindex" }
-distrans_peer = { version = "0.1", path = "distrans-peer" }
+distrans_fileindex = { version = "0", path = "distrans-fileindex" }
+distrans_peer = { version = "0", path = "distrans-peer" }
 flume = "0.11"
 futures = "0.3"
 metrics = "0.22"
-metrics-exporter-prometheus = { version = "0.13.0", features = ["http-listener"] }
+metrics-exporter-prometheus = { version = "0.13", features = ["http-listener"] }
 rust-crypto = "0.2"
 tokio = "1.33"
 tokio-util = "0.7"

--- a/distrans-fileindex/Cargo.toml
+++ b/distrans-fileindex/Cargo.toml
@@ -10,6 +10,7 @@ description = "Distrans file indexing"
 documentation = "https://docs.rs/distrans_fileindex"
 
 [dependencies]
+flume = "0.11"
 rust-crypto = "0.2"
 thiserror = "1.0"
 tokio = { version = "1.33", features = ["fs", "io-util", "macros", "rt"] }

--- a/distrans-fileindex/src/lib.rs
+++ b/distrans-fileindex/src/lib.rs
@@ -15,7 +15,7 @@ pub use crate::error::{other_err, Error, Result};
 
 pub const BLOCK_SIZE_BYTES: usize = 32768;
 pub const PIECE_SIZE_BLOCKS: usize = 32; // 32 * 32KB blocks = 1MB
-const PIECE_SIZE_BYTES: usize = PIECE_SIZE_BLOCKS * BLOCK_SIZE_BYTES;
+pub const PIECE_SIZE_BYTES: usize = PIECE_SIZE_BLOCKS * BLOCK_SIZE_BYTES;
 const INDEX_BUFFER_SIZE: usize = 67108864; // 64MB
 
 #[derive(Debug, PartialEq, Clone)]

--- a/distrans-peer/Cargo.toml
+++ b/distrans-peer/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 capnp = "0.18"
 distrans_fileindex = { version = "0", path = "../distrans-fileindex" }
 flume = "0.11"
+hex = "0.4"
 path-absolutize = "3.1"
 thiserror = "1.0"
 tokio = "1.33"

--- a/distrans-peer/Cargo.toml
+++ b/distrans-peer/Cargo.toml
@@ -16,9 +16,9 @@ path = "src/lib.rs"
 
 [dependencies]
 capnp = "0.18"
-distrans_fileindex = "0.1.0"
+distrans_fileindex = { version = "0", path = "../distrans-fileindex" }
 flume = "0.11"
-path-absolutize = "3.1.1"
+path-absolutize = "3.1"
 thiserror = "1.0"
 tokio = "1.33"
 tokio-util = "0.7"

--- a/distrans-peer/src/error.rs
+++ b/distrans-peer/src/error.rs
@@ -1,6 +1,6 @@
 use std::{array::TryFromSliceError, io, num::TryFromIntError};
 
-use veilid_core::VeilidAPIError;
+use veilid_core::{Target, VeilidAPIError};
 
 use crate::proto;
 
@@ -24,6 +24,8 @@ pub enum Error {
     NotReady,
     #[error("other: {0}")]
     Other(String),
+    #[error("route changed")]
+    RouteChanged{target: Target},
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/distrans-peer/src/fetcher.rs
+++ b/distrans-peer/src/fetcher.rs
@@ -10,7 +10,7 @@ use tokio::fs::File;
 use tokio::io::{AsyncSeekExt, AsyncWriteExt, SeekFrom};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, instrument, warn, Level};
+use tracing::{debug, instrument, warn};
 use veilid_core::{
     CryptoKey, CryptoTyped, FromStr, RoutingContext, Target, TypedKey, VeilidAPIError,
 };

--- a/distrans-peer/src/proto/mod.rs
+++ b/distrans-peer/src/proto/mod.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)]
 mod distrans_capnp;
 
 use std::{array::TryFromSliceError, num::TryFromIntError, path::PathBuf, str::Utf8Error};

--- a/src/bin/distrans.rs
+++ b/src/bin/distrans.rs
@@ -30,8 +30,11 @@ impl Cli {
             return Ok(s.to_owned());
         }
         match self.commands {
-            Commands::Get { ref dht_key, ref root } => self.state_dir_for(format!("{}:{}", dht_key, root)),
-            Commands::Post { ref file } => self.state_dir_for(file.to_owned()),
+            Commands::Get {
+                ref dht_key,
+                ref root,
+            } => self.state_dir_for(format!("get:{}:{}", dht_key, root)),
+            Commands::Post { ref file } => self.state_dir_for(format!("post:{}", file.to_owned())),
         }
     }
 
@@ -40,8 +43,9 @@ impl Cli {
         key_digest.input(&key.as_bytes());
         let dir_name = key_digest.result_str();
         let data_dir =
-            dirs::data_dir().ok_or(Error::Other("cannot resolve data dir".to_string()))?;
+            dirs::state_dir().ok_or(Error::Other("cannot resolve state dir".to_string()))?;
         let state_dir = data_dir
+            .join("distrans")
             .join(dir_name)
             .into_os_string()
             .into_string()


### PR DESCRIPTION
Separating piece indexing to multiple threads.

Be almost as fast as sha256sum.

```
$ ls -l kali-linux-2023.2a-installer-amd64.iso
-rw-r--r-- 1 user users 3951689728 Aug  5  2023 kali-linux-2023.2a-installer-amd64.iso
$ time -p sha256sum kali-linux-2023.2a-installer-amd64.iso
4aeaac60c69fb7137beaaef1fa48c194431274bcb8abf2d9f01c1087c8263b6a  kali-linux-2023.2a-installer-amd64.iso
real 26.43
user 24.81
sys 1.34
```

TODOs:

- [X] join multiple scanners properly & safely
- [X] downsize buffer if file or remaining pieces < INDEX_BUFFER_SIZE
- [X] test edge cases around file, piece, buffer sizes
- [x] try moving file reads to scanner threads, still about 6x slower than sha256sum

Update:

We're not as fast as sha256sum yet, but that's been added to the backlog.