### PR TITLE
chore: only announce top-level crate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,8 @@ jobs:
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' }}
+    # NOTE: customized to only publish Github releases for the workspace crate
+    if: ${{ always() && needs.host.result == 'success' && startsWith(github.ref_name, 'distrans-v') }}
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Publishing Github releases for all the subcrates tends to clutter up the releases.