### PR TITLE
chore: nix flake build

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ Then `cargo install distrans` and other `cargo` commands should work.
 
 The original author of this project develops on NixOS. If you Nix too,
 
+### Developing
+
 `nix develop` in here to get a devshell, then
 
 `cargo build` and other `cargo` commands to do things.
+
+### Running
+
+`nix run github:cmars/distrans`
 
 ## CICD
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1711407199,
+        "narHash": "sha256-A/nB4j3JHL51ztlMQdfKw6y8tUJJzai3bLsZUEEaBxY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "7e468a455506f2e65550e08dfd45092f0857a009",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -35,6 +55,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,12 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
+
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, crane }:
     (flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -46,6 +49,19 @@
           ]);
 
           LIBCLANG_PATH="${pkgs.llvmPackages.libclang.lib}/lib";
+        };
+
+        packages.default = crane.lib.${system}.buildPackage {
+          src = ./.;
+
+          buildInputs = with pkgs; [
+            cargo
+            rust-bin.stable.latest.default
+            capnproto
+            protobuf
+            pkg-config
+            openssl
+          ];
         };
       }
     ));


### PR DESCRIPTION
Add default package to flake, so you can `nix build` and `nix run` it.