### PR TITLE
fix: log scrolling in tui, fetch digest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1.36", features = ["full"] }
 
 [package]
 name = "distrans"
+default-run = "distrans"
 description = "Anonymous decentralized file distribution and transfer"
 authors.workspace = true
 documentation.workspace = true

--- a/distrans-peer/src/fetcher.rs
+++ b/distrans-peer/src/fetcher.rs
@@ -111,6 +111,10 @@ impl Fetcher {
             .join(",")
     }
 
+    pub fn digest(&self) -> String {
+        hex::encode(self.index.payload().digest())
+    }
+
     pub async fn fetch(self, cancel: CancellationToken) -> Result<()> {
         let (fetch_block_sender, fetch_block_receiver) = unbounded();
         let (verify_sender, verify_receiver) = unbounded();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 
 pub fn initialize_stderr_logging() {
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stdout))
         .with(
             EnvFilter::builder()
                 .with_default_directive("distrans=debug".parse().unwrap())


### PR DESCRIPTION
Display sha256 digest when fetching, fixes #20.

Fix log scrolling, provide required size in the custom view, fixes #18

Drive-by: set default binary (distrans) in package manifest.
Drive-by: non-ui log output to stdout instead of stderr.