### PR TITLE
refactor!: introduce peer abstraction, goal-seeking behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -324,6 +324,20 @@ name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
 
 [[package]]
 name = "backtrace"
@@ -1077,6 +1091,7 @@ dependencies = [
 name = "distrans_peer"
 version = "0.1.11"
 dependencies = [
+ "backoff",
  "capnp",
  "capnpc",
  "distrans_fileindex",
@@ -1089,6 +1104,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "veilid-core",
 ]
 

--- a/distrans-fileindex/src/lib.rs
+++ b/distrans-fileindex/src/lib.rs
@@ -8,9 +8,9 @@ use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::{fs::File, task::JoinSet};
 
-mod error;
-
 pub use crate::error::{other_err, Error, Result};
+
+mod error;
 
 pub const BLOCK_SIZE_BYTES: usize = 32768;
 pub const PIECE_SIZE_BLOCKS: usize = 32; // 32 * 32KB blocks = 1MB
@@ -380,12 +380,14 @@ impl PayloadPiece {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use hex_literal::hex;
     use std::io::Write;
+
+    use hex_literal::hex;
     use tempfile::NamedTempFile;
 
-    fn temp_file(pattern: u8, count: usize) -> NamedTempFile {
+    use super::*;
+
+    pub fn temp_file(pattern: u8, count: usize) -> NamedTempFile {
         let mut tempf = NamedTempFile::new().expect("temp file");
         let contents = vec![pattern; count];
         tempf.write(contents.as_slice()).expect("write temp file");

--- a/distrans-peer/Cargo.toml
+++ b/distrans-peer/Cargo.toml
@@ -15,6 +15,7 @@ name = "distrans_peer"
 path = "src/lib.rs"
 
 [dependencies]
+backoff = { version = "0.4.0", features = ["tokio"] }
 capnp = "0.18"
 distrans_fileindex = { version = "0", path = "../distrans-fileindex" }
 flume = "0.11"
@@ -44,3 +45,4 @@ sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3.10"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/distrans-peer/src/error.rs
+++ b/distrans-peer/src/error.rs
@@ -1,35 +1,204 @@
-use std::{array::TryFromSliceError, io, num::TryFromIntError};
+use std::{array::TryFromSliceError, fmt, io, num::TryFromIntError, path::PathBuf};
 
-use veilid_core::{Target, VeilidAPIError};
+use veilid_core::VeilidAPIError;
 
 use crate::proto;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(Debug)]
 pub enum Error {
-    #[error("io error: {0}")]
-    IO(#[from] io::Error),
-    #[error("veilid api error: {0}")]
-    VeilidAPI(#[from] VeilidAPIError),
-    #[error("utf-8 encoding error: {0}")]
-    Utf8(#[from] std::str::Utf8Error),
-    #[error("fileindex error: {0}")]
-    FileIndex(#[from] distrans_fileindex::Error),
-    #[error("proto error: {0}")]
-    Proto(#[from] proto::Error),
-    #[error("{0}")]
-    IntOverflow(#[from] TryFromIntError),
-    #[error("{0}")]
-    SliceSize(#[from] TryFromSliceError),
-    #[error("not ready")]
-    NotReady,
-    #[error("other: {0}")]
+    /// Unexpected fault.
+    Fault(Unexpected),
+    /// Error related to file indexing.
+    Index {
+        path: Option<PathBuf>,
+        err: distrans_fileindex::Error,
+    },
+    /// Error caused by local filesystem operation.
+    LocalFile(io::Error),
+    /// Error caused by Veilid network operation.
+    Node {
+        state: NodeState,
+        err: VeilidAPIError,
+    },
+    /// Protocol error when decoding a message from a remote peer.
+    /// Similar to an HTTP 400, "it's not me it's you."
+    RemoteProtocol(proto::Error),
+    /// Protocol error when trying to encode a message.
+    /// Similar to an HTTP 500, "it's not you it's me."
+    InternalProtocol(proto::Error),
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Fault(u) => write!(f, "unexpected fault: {}", u),
+            Error::Index { path, err } => write!(
+                f,
+                "failed to index{}: {}",
+                match path {
+                    Some(p) => format!(" {:?}", p),
+                    None => "".to_string(),
+                },
+                err
+            ),
+            Error::LocalFile(err) => {
+                write!(f, "file operation failed: {}", err)
+            }
+            Error::Node { state, err } => write!(f, "{}: {}", state, err),
+            Error::RemoteProtocol(e) => write!(f, "invalid response from remote peer: {}", e),
+            Error::InternalProtocol(e) => write!(f, "failed to encode protocol message: {}", e),
+        }
+    }
+}
+
+impl From<VeilidAPIError> for Error {
+    fn from(err: VeilidAPIError) -> Self {
+        match err {
+            VeilidAPIError::NotInitialized => Error::Node {
+                state: NodeState::APINotStarted,
+                err,
+            },
+            VeilidAPIError::AlreadyInitialized => Error::Fault(Unexpected::Veilid(err)),
+            VeilidAPIError::Timeout => Error::Node {
+                state: NodeState::RemotePeerNotAvailable,
+                err,
+            },
+            VeilidAPIError::TryAgain { message: _ } => Error::Node {
+                state: NodeState::RemotePeerNotAvailable,
+                err,
+            },
+            VeilidAPIError::Shutdown => Error::Node {
+                state: NodeState::APIShuttingDown,
+                err,
+            },
+            VeilidAPIError::InvalidTarget { message: _ } => Error::Node {
+                state: NodeState::PrivateRouteInvalid,
+                err,
+            },
+            VeilidAPIError::NoConnection { message: _ } => Error::Node {
+                state: NodeState::NetworkNotAvailable,
+                err,
+            },
+            VeilidAPIError::KeyNotFound { key: _ } => Error::Node {
+                state: NodeState::RemotePeerNotAvailable,
+                err,
+            },
+            VeilidAPIError::Internal { message: _ } => Error::Fault(Unexpected::Veilid(err)),
+            VeilidAPIError::Unimplemented { message: _ } => Error::Fault(Unexpected::Veilid(err)),
+            VeilidAPIError::ParseError {
+                message: _,
+                value: _,
+            } => Error::Fault(Unexpected::Veilid(err)),
+            VeilidAPIError::InvalidArgument {
+                context: _,
+                argument: _,
+                value: _,
+            } => Error::Fault(Unexpected::Veilid(err)),
+            VeilidAPIError::MissingArgument {
+                context: _,
+                argument: _,
+            } => Error::Fault(Unexpected::Veilid(err)),
+            VeilidAPIError::Generic { message: _ } => Error::Fault(Unexpected::Veilid(err)),
+        }
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(err: std::str::Utf8Error) -> Self {
+        Error::Fault(Unexpected::Utf8(err))
+    }
+}
+impl From<TryFromIntError> for Error {
+    fn from(err: TryFromIntError) -> Self {
+        Error::Fault(Unexpected::IntOverflow(err))
+    }
+}
+impl From<TryFromSliceError> for Error {
+    fn from(err: TryFromSliceError) -> Self {
+        Error::Fault(Unexpected::SliceSize(err))
+    }
+}
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::LocalFile(err)
+    }
+}
+
+impl Error {
+    pub fn other<S: ToString>(e: S) -> Error {
+        Error::Fault(Unexpected::Other(e.to_string()))
+    }
+    pub fn index(err: distrans_fileindex::Error) -> Error {
+        Error::Index { path: None, err }
+    }
+    pub fn remote_protocol(err: proto::Error) -> Error {
+        Error::RemoteProtocol(err)
+    }
+    pub fn internal_protocol(err: proto::Error) -> Error {
+        Error::InternalProtocol(err)
+    }
+
+    pub fn is_route_invalid(err: &Error) -> bool {
+        if let Error::Node { state, err: _ } = err {
+            *state == NodeState::PrivateRouteInvalid
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum NodeState {
+    APINotStarted,
+    NetworkNotAvailable,
+    RemotePeerNotAvailable,
+    PrivateRouteInvalid,
+    Connecting,
+    Connected,
+    APIShuttingDown,
+}
+
+impl NodeState {
+    pub fn is_connected(node_state: &Self) -> bool {
+        *node_state == NodeState::Connected
+    }
+}
+
+impl fmt::Display for NodeState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NodeState::APINotStarted => write!(f, "api not started"),
+            NodeState::NetworkNotAvailable => write!(f, "network not available"),
+            NodeState::RemotePeerNotAvailable => write!(f, "remote peer not available"),
+            NodeState::PrivateRouteInvalid => write!(f, "private route invalid"),
+            NodeState::APIShuttingDown => write!(f, "api shutdown in progress"),
+            NodeState::Connecting => write!(f, "connecting to network"),
+            NodeState::Connected => write!(f, "connected"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Unexpected {
+    Veilid(VeilidAPIError),
+    Utf8(std::str::Utf8Error),
+    IntOverflow(TryFromIntError),
+    SliceSize(TryFromSliceError),
     Other(String),
-    #[error("route changed")]
-    RouteChanged{target: Target},
+}
+
+impl fmt::Display for Unexpected {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Unexpected::Veilid(e) => write!(f, "veilid: {}", e),
+            Unexpected::Utf8(e) => write!(f, "utf8 encoding failed: {}", e),
+            Unexpected::IntOverflow(e) => write!(f, "integer overflow: {}", e),
+            Unexpected::SliceSize(e) => write!(f, "unexpected slice size: {}", e),
+            Unexpected::Other(e) => write!(f, "{}", e),
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
-
-pub fn other_err<T: ToString>(e: T) -> Error {
-    Error::Other(e.to_string())
-}

--- a/distrans-peer/src/lib.rs
+++ b/distrans-peer/src/lib.rs
@@ -1,61 +1,50 @@
 mod error;
 mod fetcher;
+mod peer;
 mod proto;
 mod seeder;
 pub mod veilid_config;
 
-use std::time::Duration;
+use std::{path::PathBuf, sync::Arc};
 
-use flume::Receiver;
-use tokio::{select, time::sleep_until};
-use tracing::{info, trace};
-use veilid_core::{RoutingContext, VeilidAPIError, VeilidUpdate};
+use tokio::sync::broadcast::{self, Receiver, Sender};
+use veilid_core::{RoutingContext, Sequencing, VeilidUpdate};
 
-pub use error::{other_err, Error, Result};
+pub use error::{Error, Result};
 pub use fetcher::Fetcher;
+pub use peer::{Peer, ResilientPeer, VeilidPeer};
 pub use seeder::Seeder;
 
-pub async fn wait_for_network<F>(updates: &Receiver<VeilidUpdate>, on_update: F) -> Result<()>
-where
-    F: Fn(&VeilidUpdate) -> (),
-{
-    let timeout = tokio::time::Instant::now()
-        .checked_add(Duration::from_secs(60))
-        .unwrap();
-    loop {
-        select! {
-            recv_update = updates.recv_async() => {
-                let update = recv_update.map_err(other_err)?;
-                on_update(&update);
-                match update {
-                    VeilidUpdate::Attachment(attachment) => {
-                        if attachment.public_internet_ready {
-                            info!("connected");
-                            break;
-                        }
-                    }
-                    VeilidUpdate::Shutdown => {
-                        return Err(VeilidAPIError::Shutdown.into());
-                    }
-                    u => {
-                        trace!(update = format!("{:?}", u));
-                    }
-                };
-            }
-            _ = sleep_until(timeout) => {
-                return Err(other_err("timed out waiting for network"));
-            }
-        }
-    }
-    Ok(())
-}
+#[cfg(test)]
+pub mod tests;
 
-pub async fn reconnect(
-    routing_context: &RoutingContext,
-    updates: &Receiver<VeilidUpdate>,
-) -> Result<()> {
-    routing_context.api().detach().await?;
-    routing_context.api().attach().await?;
-    wait_for_network(updates, |_| {}).await?;
-    Ok(())
+const VEILID_UPDATE_CAPACITY: usize = 1024;
+
+pub async fn new_routing_context(
+    state_dir: &str,
+) -> Result<(RoutingContext, Sender<VeilidUpdate>, Receiver<VeilidUpdate>)> {
+    let state_path_buf = PathBuf::from(state_dir);
+
+    let (cb_update_tx, update_rx): (Sender<VeilidUpdate>, Receiver<VeilidUpdate>) =
+        broadcast::channel(VEILID_UPDATE_CAPACITY);
+    let update_tx = cb_update_tx.clone();
+
+    // Configure Veilid core
+    let update_callback = Arc::new(move |change: VeilidUpdate| {
+        let _ = cb_update_tx.send(change);
+    });
+    let config_state_path = Arc::new(state_path_buf);
+    let config_callback = Arc::new(move |key| {
+        veilid_config::callback(config_state_path.to_str().unwrap().to_string(), key)
+    });
+
+    // Start Veilid API
+    let api: veilid_core::VeilidAPI =
+        veilid_core::api_startup(update_callback, config_callback).await?;
+
+    let routing_context = api
+        .routing_context()?
+        .with_sequencing(Sequencing::EnsureOrdered)
+        .with_default_safety()?;
+    Ok((routing_context, update_tx, update_rx))
 }

--- a/distrans-peer/src/peer/mod.rs
+++ b/distrans-peer/src/peer/mod.rs
@@ -1,0 +1,58 @@
+use std::{future::Future, path::Path};
+
+use tokio::sync::broadcast::Receiver;
+use veilid_core::{CryptoKey, CryptoTyped, OperationId, Target, VeilidUpdate};
+
+use distrans_fileindex::Index;
+
+use crate::{proto::Header, Result};
+
+pub type ShareKey = CryptoTyped<CryptoKey>;
+
+pub trait Peer: Clone + Send {
+    fn subscribe_veilid_update(&self) -> Receiver<VeilidUpdate>;
+
+    fn reset(&mut self) -> impl Future<Output = Result<()>> + Send;
+    fn shutdown(self) -> impl Future<Output = Result<()>> + Send;
+
+    fn announce(
+        &mut self,
+        index: &Index,
+    ) -> impl std::future::Future<Output = Result<(ShareKey, Target, Header)>> + Send;
+    fn reannounce_route(
+        &mut self,
+        key: &ShareKey,
+        prior_route: Option<Target>,
+        index: &Index,
+        header: &Header,
+    ) -> impl std::future::Future<Output = Result<(Target, Header)>> + Send;
+
+    fn resolve(
+        &mut self,
+        key: &ShareKey,
+        root: &Path,
+    ) -> impl std::future::Future<Output = Result<(Target, Header, Index)>> + Send;
+    fn reresolve_route(
+        &mut self,
+        key: &ShareKey,
+        prior_route: Option<Target>,
+    ) -> impl Future<Output = Result<(Target, Header)>> + Send;
+
+    fn request_block(
+        &mut self,
+        target: Target,
+        piece: usize,
+        block: usize,
+    ) -> impl Future<Output = Result<Vec<u8>>> + Send;
+    fn reply_block_contents(
+        &mut self,
+        call_id: OperationId,
+        contents: &[u8],
+    ) -> impl std::future::Future<Output = Result<()>> + Send;
+}
+
+mod veilid_peer;
+pub use veilid_peer::VeilidPeer;
+
+mod resilient_peer;
+pub use resilient_peer::ResilientPeer;

--- a/distrans-peer/src/peer/resilient_peer.rs
+++ b/distrans-peer/src/peer/resilient_peer.rs
@@ -1,0 +1,585 @@
+use std::{path::Path, time::Duration};
+
+use backoff::{backoff::Backoff, ExponentialBackoff};
+use distrans_fileindex::Index;
+use tokio::{
+    select,
+    sync::{broadcast::Receiver, watch},
+    time::sleep,
+};
+use tracing::{debug, instrument};
+use veilid_core::{OperationId, Target, VeilidAPIError, VeilidUpdate};
+
+use crate::{
+    error::Error,
+    error::Result,
+    error::{NodeState, Unexpected},
+    proto::Header,
+    Peer,
+};
+
+use super::ShareKey;
+
+pub struct ResilientPeer<P: Peer> {
+    peer: P,
+    node_state_rx: tokio::sync::watch::Receiver<NodeState>,
+    initial_retry_backoff: ExponentialBackoff,
+    initial_reset_backoff: ExponentialBackoff,
+}
+
+impl<P: Peer + 'static> ResilientPeer<P> {
+    pub fn new(p: P) -> ResilientPeer<P> {
+        let updates = p.subscribe_veilid_update();
+        let (tx, rx) = watch::channel(NodeState::APINotStarted);
+        tokio::spawn(Self::track_node_state(updates, tx));
+        ResilientPeer {
+            peer: p,
+            node_state_rx: rx,
+            initial_retry_backoff: Self::default_retry_backoff(),
+            initial_reset_backoff: Self::default_reset_backoff(),
+        }
+    }
+
+    pub fn with_backoff(
+        self,
+        retry_backoff: ExponentialBackoff,
+        reset_backoff: ExponentialBackoff,
+    ) -> Self {
+        ResilientPeer {
+            peer: self.peer,
+            node_state_rx: self.node_state_rx,
+            initial_retry_backoff: retry_backoff,
+            initial_reset_backoff: reset_backoff,
+        }
+    }
+
+    async fn track_node_state(
+        mut updates: Receiver<VeilidUpdate>,
+        tx: tokio::sync::watch::Sender<NodeState>,
+    ) -> Result<()> {
+        loop {
+            let update = updates.recv().await.map_err(Error::other)?;
+            match update {
+                VeilidUpdate::Attachment(attachment) => {
+                    let is_attach = match attachment.state {
+                        veilid_core::AttachmentState::Detached => false,
+                        veilid_core::AttachmentState::Attaching => true,
+                        veilid_core::AttachmentState::AttachedWeak => true,
+                        veilid_core::AttachmentState::AttachedGood => true,
+                        veilid_core::AttachmentState::AttachedStrong => true,
+                        veilid_core::AttachmentState::FullyAttached => true,
+                        veilid_core::AttachmentState::OverAttached => true,
+                        _ => false,
+                    };
+                    let updated_state = if attachment.public_internet_ready {
+                        NodeState::Connected
+                    } else if is_attach {
+                        NodeState::Connecting
+                    } else {
+                        NodeState::NetworkNotAvailable
+                    };
+                    debug!(
+                        state = format!("{}", updated_state),
+                        attachment = format!("{:?}", attachment)
+                    );
+                    tx.send(updated_state).map_err(Error::other)?;
+                }
+                VeilidUpdate::Shutdown => {
+                    debug!(state = format!("{}", NodeState::APIShuttingDown));
+                    tx.send(NodeState::APIShuttingDown).map_err(Error::other)?;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Ok::<(), Error>(())
+    }
+
+    fn is_retryable(err: &Error) -> bool {
+        match err {
+            Error::Fault(_) => true,
+            Error::Index { path: _, err: _ } => false,
+            Error::LocalFile(_) => false,
+            Error::Node { state, err: _ } => *state == NodeState::RemotePeerNotAvailable,
+            Error::RemoteProtocol(_) => true,
+            Error::InternalProtocol(_) => false,
+        }
+    }
+
+    fn is_resettable(err: &Error) -> bool {
+        match err {
+            Error::Index { path: _, err: _ } => false,
+            Error::LocalFile(_) => false,
+            Error::InternalProtocol(_) => false,
+            Error::Node { state, err: _ } => match state {
+                NodeState::APIShuttingDown => false,
+                NodeState::PrivateRouteInvalid => false,
+                _ => true,
+            },
+            Error::Fault(err) => match err {
+                Unexpected::Veilid(VeilidAPIError::Unimplemented { message: _ }) => false,
+                Unexpected::Veilid(_) => true,
+                _ => false,
+            },
+            _ => true,
+        }
+    }
+
+    fn default_retry_backoff() -> ExponentialBackoff {
+        let mut back_off = ExponentialBackoff::default();
+        back_off.max_elapsed_time = Some(Duration::from_secs(120));
+        back_off
+    }
+
+    fn default_reset_backoff() -> ExponentialBackoff {
+        let mut back_off = ExponentialBackoff::default();
+        back_off.max_elapsed_time = None;
+        back_off
+    }
+
+    fn retry_backoff(&self) -> ExponentialBackoff {
+        self.initial_retry_backoff.clone()
+    }
+
+    fn reset_backoff(&self) -> ExponentialBackoff {
+        self.initial_reset_backoff.clone()
+    }
+
+    async fn retry_delay(&mut self, back_off: &mut ExponentialBackoff, err: Error) -> Result<()> {
+        if Self::is_retryable(&err) {
+            if let Some(delay) = back_off.next_backoff() {
+                debug!(
+                    err = format!("{}", err),
+                    delay = format!("{:?}", delay),
+                    "retry"
+                );
+                tokio::time::sleep(delay).await;
+                return Ok(());
+            }
+        }
+        if Self::is_resettable(&err) {
+            debug!(err = format!("{}", err), "resetting connection");
+            self.reset().await?;
+            back_off.reset();
+            return Ok(());
+        }
+        Err(err)
+    }
+}
+
+impl<P: Peer + 'static> Peer for ResilientPeer<P> {
+    fn subscribe_veilid_update(&self) -> Receiver<VeilidUpdate> {
+        self.peer.subscribe_veilid_update()
+    }
+
+    #[instrument(skip(self), level = "debug", err)]
+    async fn reset(&mut self) -> Result<()> {
+        let mut back_off = self.reset_backoff();
+        loop {
+            match self.peer.reset().await {
+                Ok(_) => {
+                    select! {
+                        wait_result = self.node_state_rx.wait_for(NodeState::is_connected) => {
+                            if let Err(e) = wait_result {
+                                return Err(Error::other(e));
+                            }
+                            return Ok(());
+                        }
+                        _ = sleep(Duration::from_secs(120)) => {
+                            continue;
+                        }
+                    }
+                }
+                Err(e) => {
+                    if Self::is_retryable(&e) || Self::is_resettable(&e) {
+                        if let Some(delay) = back_off.next_backoff() {
+                            select! {
+                                _ = sleep(delay) => continue,
+                                watch_result = self.node_state_rx.wait_for(NodeState::is_connected) => {
+                                    if let Err(_) = watch_result {
+                                        return Err(e);
+                                    }
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    #[instrument(skip(self), level = "debug", err)]
+    async fn shutdown(self) -> Result<()> {
+        self.peer.shutdown().await
+    }
+
+    #[instrument(skip(self, index), level = "debug", err)]
+    async fn announce(&mut self, index: &Index) -> Result<(ShareKey, Target, Header)> {
+        let mut back_off = self.retry_backoff();
+        loop {
+            match self.peer.announce(index).await {
+                Ok(resp) => return Ok(resp),
+                Err(e) => {
+                    self.retry_delay(&mut back_off, e).await?;
+                    continue;
+                }
+            }
+        }
+    }
+
+    #[instrument(skip(self, index, header), level = "debug", err)]
+    async fn reannounce_route(
+        &mut self,
+        key: &ShareKey,
+        prior_route: Option<Target>,
+        index: &Index,
+        header: &Header,
+    ) -> Result<(Target, Header)> {
+        let mut back_off = self.retry_backoff();
+        loop {
+            match self
+                .peer
+                .reannounce_route(key, prior_route, index, header)
+                .await
+            {
+                Ok(resp) => return Ok(resp),
+                Err(e) => {
+                    self.retry_delay(&mut back_off, e).await?;
+                    continue;
+                }
+            }
+        }
+    }
+
+    #[instrument(skip(self), level = "debug", err)]
+    async fn resolve(&mut self, key: &ShareKey, root: &Path) -> Result<(Target, Header, Index)> {
+        let mut back_off = self.retry_backoff();
+        loop {
+            match self.peer.resolve(key, root).await {
+                Ok(resp) => return Ok(resp),
+                Err(e) => {
+                    self.retry_delay(&mut back_off, e).await?;
+                    continue;
+                }
+            }
+        }
+    }
+
+    #[instrument(skip(self), level = "debug", err)]
+    async fn reresolve_route(
+        &mut self,
+        key: &ShareKey,
+        prior_route: Option<Target>,
+    ) -> Result<(Target, Header)> {
+        let mut back_off = self.retry_backoff();
+        loop {
+            match self.peer.reresolve_route(key, prior_route).await {
+                Ok(resp) => return Ok(resp),
+                Err(e) => {
+                    self.retry_delay(&mut back_off, e).await?;
+                    continue;
+                }
+            }
+        }
+    }
+
+    #[instrument(skip(self), level = "debug", err)]
+    async fn request_block(
+        &mut self,
+        target: Target,
+        piece: usize,
+        block: usize,
+    ) -> Result<Vec<u8>> {
+        let mut back_off = self.retry_backoff();
+        loop {
+            match self.peer.request_block(target, piece, block).await {
+                Ok(resp) => return Ok(resp),
+                Err(e) => {
+                    self.retry_delay(&mut back_off, e).await?;
+                    continue;
+                }
+            }
+        }
+    }
+
+    #[instrument(skip(self, contents), level = "debug", err)]
+    async fn reply_block_contents(&mut self, call_id: OperationId, contents: &[u8]) -> Result<()> {
+        let mut back_off = ExponentialBackoff::default();
+        loop {
+            match self.peer.reply_block_contents(call_id, contents).await {
+                Ok(resp) => return Ok(resp),
+                Err(e) => {
+                    self.retry_delay(&mut back_off, e).await?;
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+impl<P: Peer> Clone for ResilientPeer<P> {
+    fn clone(&self) -> Self {
+        ResilientPeer {
+            peer: self.peer.clone(),
+            node_state_rx: self.node_state_rx.clone(),
+            initial_retry_backoff: self.initial_retry_backoff.clone(),
+            initial_reset_backoff: self.initial_reset_backoff.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use veilid_core::{FromStr, TypedKey, VeilidStateAttachment};
+
+    use crate::proto;
+    use crate::tests::StubPeer;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn reset_ok() {
+        let mut stub_peer = StubPeer::new();
+        let update_tx = stub_peer.update_tx.clone();
+        let reset_calls = Arc::new(Mutex::new(0));
+        let reset_calls_internal = reset_calls.clone();
+        stub_peer.reset_result = Arc::new(Mutex::new(move || {
+            (*(reset_calls_internal.lock().unwrap())) += 1;
+            Ok(())
+        }));
+        let mut rp = ResilientPeer::new(stub_peer);
+        // Simulate getting connected to network, normally track_node_state
+        // would set this when the node comes online.
+        update_tx
+            .send(VeilidUpdate::Attachment(Box::new(VeilidStateAttachment {
+                state: veilid_core::AttachmentState::AttachedGood,
+                public_internet_ready: true,
+                local_network_ready: true,
+            })))
+            .expect("send veilid update");
+        rp.reset().await.unwrap();
+        // Simulate a shutdown so that track_node_state exits.
+        update_tx
+            .send(VeilidUpdate::Shutdown)
+            .expect("send veilid update");
+        // reset was called once
+        assert_eq!(*(reset_calls.lock().unwrap()), 1);
+    }
+
+    #[tokio::test]
+    async fn reset_recover() {
+        let mut stub_peer = StubPeer::new();
+        let update_tx = stub_peer.update_tx.clone();
+        let update_tx_internal = update_tx.clone();
+        let reset_calls = Arc::new(Mutex::new(0));
+        let reset_calls_internal = reset_calls.clone();
+        stub_peer.reset_result = Arc::new(Mutex::new(move || {
+            let mut calls = reset_calls_internal.lock().unwrap();
+            let result = if *calls < 5 {
+                // Send a retryable error that causes reset to backoff-retry
+                Err(Error::RemoteProtocol(proto::Error::Other(
+                    "bad response".to_string(),
+                )))
+            } else {
+                // Simulate "coming online"
+                update_tx_internal
+                    .send(VeilidUpdate::Attachment(Box::new(VeilidStateAttachment {
+                        state: veilid_core::AttachmentState::AttachedGood,
+                        public_internet_ready: true,
+                        local_network_ready: true,
+                    })))
+                    .expect("send veilid update");
+                Ok(())
+            };
+            *calls += 1;
+            result
+        }));
+        let mut rp = ResilientPeer::new(stub_peer);
+        // Zero out the backoff retry delays for a faster test
+        rp.initial_reset_backoff.initial_interval = Duration::ZERO;
+        rp.initial_reset_backoff.multiplier = 0.0;
+        // reset eventually succeeds
+        rp.reset().await.unwrap();
+        // on the 6th attempt
+        assert_eq!(*(reset_calls.lock().unwrap()), 6);
+        update_tx
+            .send(VeilidUpdate::Shutdown)
+            .expect("send veilid update");
+    }
+
+    #[tokio::test]
+    async fn reset_nonrecoverable() {
+        let mut stub_peer = StubPeer::new();
+        let update_tx = stub_peer.update_tx.clone();
+        let reset_calls = Arc::new(Mutex::new(0));
+        let reset_calls_internal = reset_calls.clone();
+        stub_peer.reset_result = Arc::new(Mutex::new(move || {
+            let mut calls = reset_calls_internal.lock().unwrap();
+            *calls += 1;
+            // Return an error that is nonrecoverable, even for a reset.
+            // An internal protocol error isn't something we'd normally send in a reset
+            // but it's indicative of an internal failure to serialize a message, which
+            // isn't going to get better if we have such a bug.
+            Err(Error::InternalProtocol(proto::Error::Other(
+                "nope".to_string(),
+            )))
+        }));
+        let mut rp = ResilientPeer::new(stub_peer);
+        let result = rp.reset().await;
+        // reset failed with the nonrecoverable error
+        assert!(matches!(result, Err(Error::InternalProtocol(_))));
+        update_tx
+            .send(VeilidUpdate::Shutdown)
+            .expect("send veilid update");
+        // reset was called once
+        assert_eq!(*(reset_calls.lock().unwrap()), 1);
+    }
+
+    #[tokio::test]
+    async fn reset_retry_exceeded() {
+        let mut stub_peer = StubPeer::new();
+        let update_tx = stub_peer.update_tx.clone();
+        let reset_calls = Arc::new(Mutex::new(0));
+        let reset_calls_internal = reset_calls.clone();
+        stub_peer.reset_result = Arc::new(Mutex::new(move || {
+            let mut calls = reset_calls_internal.lock().unwrap();
+            *calls += 1;
+            // Return a recoverable error
+            Err(Error::Fault(Unexpected::Veilid(
+                VeilidAPIError::Unimplemented {
+                    message: "nope".to_string(),
+                },
+            )))
+        }));
+        let mut rp = ResilientPeer::new(stub_peer);
+        // Configure the retry threshold to zero, simulating a backoff retries
+        // exceeded condition.
+        rp.initial_reset_backoff.max_elapsed_time = Some(Duration::ZERO);
+        let result = rp.reset().await;
+        // Last error returned
+        assert!(matches!(result, Err(Error::Fault(Unexpected::Veilid(_)))));
+        update_tx
+            .send(VeilidUpdate::Shutdown)
+            .expect("send veilid update");
+        // reset calledat least once
+        assert!(*(reset_calls.lock().unwrap()) >= 1);
+    }
+
+    #[tokio::test]
+    async fn request_block_ok() {
+        let mut stub_peer = StubPeer::new();
+        let update_tx = stub_peer.update_tx.clone();
+        let calls = Arc::new(Mutex::new(0));
+        let calls_internal = calls.clone();
+        stub_peer.request_block_result = Arc::new(Mutex::new(move || {
+            // Simulate a request_block peer call that succeeds.
+            (*(calls_internal.lock().unwrap())) += 1;
+            Ok(vec![0xde, 0xad, 0xbe, 0xef])
+        }));
+        let mut rp = ResilientPeer::new(stub_peer);
+        update_tx
+            .send(VeilidUpdate::Attachment(Box::new(VeilidStateAttachment {
+                state: veilid_core::AttachmentState::AttachedGood,
+                public_internet_ready: true,
+                local_network_ready: true,
+            })))
+            .expect("send veilid update");
+        // Fake a target
+        let key = TypedKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M")
+            .expect("parsed key");
+        let response = rp
+            .request_block(Target::PrivateRoute(key.value), 0, 0)
+            .await
+            .unwrap();
+        // Got simulated block contents
+        assert_eq!(response, vec![0xde, 0xad, 0xbe, 0xef]);
+        update_tx
+            .send(VeilidUpdate::Shutdown)
+            .expect("send veilid update");
+        // request_block called once
+        assert_eq!(*(calls.lock().unwrap()), 1);
+    }
+
+    #[tokio::test]
+    async fn request_block_recover() {
+        let mut stub_peer = StubPeer::new();
+        let update_tx = stub_peer.update_tx.clone();
+        let calls = Arc::new(Mutex::new(0));
+        let calls_internal = calls.clone();
+        stub_peer.request_block_result = Arc::new(Mutex::new(move || {
+            let mut call = calls_internal.lock().unwrap();
+            let result = if *call < 5 {
+                // Temporary recoverable failure condition.
+                // The remote peer is responding with garbage.
+                Err(Error::RemoteProtocol(proto::Error::Other(
+                    "nope".to_string(),
+                )))
+            } else {
+                // Finally got a good response.
+                Ok(vec![0xde, 0xad, 0xbe, 0xef])
+            };
+            *call += 1;
+            result
+        }));
+        let mut rp = ResilientPeer::new(stub_peer);
+        // Zero out backoff delays for speed.
+        rp.initial_retry_backoff.initial_interval = Duration::ZERO;
+        rp.initial_retry_backoff.multiplier = 0.0;
+        update_tx
+            .send(VeilidUpdate::Attachment(Box::new(VeilidStateAttachment {
+                state: veilid_core::AttachmentState::AttachedGood,
+                public_internet_ready: true,
+                local_network_ready: true,
+            })))
+            .expect("send veilid update");
+        let key = TypedKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M")
+            .expect("parsed key");
+        let response = rp
+            .request_block(Target::PrivateRoute(key.value), 0, 0)
+            .await
+            .unwrap();
+        // Got simulated block contents
+        assert_eq!(response, vec![0xde, 0xad, 0xbe, 0xef]);
+        update_tx
+            .send(VeilidUpdate::Shutdown)
+            .expect("send veilid update");
+        // 6th time's a charm
+        assert_eq!(*(calls.lock().unwrap()), 6);
+    }
+
+    #[tokio::test]
+    async fn request_block_nonrecoverable() {
+        let mut stub_peer = StubPeer::new();
+        let update_tx = stub_peer.update_tx.clone();
+        stub_peer.request_block_result = Arc::new(Mutex::new(move || {
+            // It's not you it's me
+            Err(Error::InternalProtocol(proto::Error::Other(
+                "nope".to_string(),
+            )))
+        }));
+        let mut rp = ResilientPeer::new(stub_peer);
+        update_tx
+            .send(VeilidUpdate::Attachment(Box::new(VeilidStateAttachment {
+                state: veilid_core::AttachmentState::AttachedGood,
+                public_internet_ready: true,
+                local_network_ready: true,
+            })))
+            .expect("send veilid update");
+        let key = TypedKey::from_str("VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M")
+            .expect("parsed key");
+        let result = rp
+            .request_block(Target::PrivateRoute(key.value), 0, 0)
+            .await;
+        assert!(matches!(
+            result,
+            Err(Error::InternalProtocol(proto::Error::Other(_)))
+        ));
+        update_tx
+            .send(VeilidUpdate::Shutdown)
+            .expect("send veilid update");
+    }
+}

--- a/distrans-peer/src/peer/veilid_peer.rs
+++ b/distrans-peer/src/peer/veilid_peer.rs
@@ -1,0 +1,261 @@
+use std::{cmp::min, path::Path};
+
+use tokio::sync::broadcast::{Receiver, Sender};
+use tracing::{debug, trace};
+use veilid_core::{
+    DHTRecordDescriptor, DHTSchema, KeyPair, OperationId, RoutingContext, Target, ValueData,
+    VeilidAPIError, VeilidUpdate,
+};
+
+use distrans_fileindex::Index;
+
+use crate::{
+    proto::{
+        decode_header, decode_index, encode_block_request, encode_header, encode_index,
+        BlockRequest, Header,
+    },
+    Error, Result,
+};
+
+use super::{Peer, ShareKey};
+
+pub struct VeilidPeer {
+    routing_context: RoutingContext,
+
+    update_tx: Sender<VeilidUpdate>,
+}
+
+impl VeilidPeer {
+    pub async fn new(
+        routing_context: RoutingContext,
+        update_tx: Sender<VeilidUpdate>,
+    ) -> Result<Self> {
+        Ok(VeilidPeer {
+            routing_context,
+            update_tx,
+        })
+    }
+
+    async fn open_or_create_dht_record(&self, header: &Header) -> Result<DHTRecordDescriptor> {
+        let ts = self.routing_context.api().table_store()?;
+        let db = ts.open("distrans_payload_dht", 2).await?;
+        let digest_key = header.payload_digest();
+        let maybe_dht_key = db.load_json(0, digest_key.as_slice()).await?;
+        let maybe_dht_owner_keypair = db.load_json(1, digest_key.as_slice()).await?;
+        if let (Some(dht_key), Some(dht_owner_keypair)) = (maybe_dht_key, maybe_dht_owner_keypair) {
+            return Ok(self
+                .routing_context
+                .open_dht_record(dht_key, dht_owner_keypair)
+                .await?);
+        }
+        let o_cnt = header.subkeys() + 1;
+        let dht_rec = self
+            .routing_context
+            .create_dht_record(DHTSchema::dflt(o_cnt)?, None)
+            .await?;
+        let dht_owner = KeyPair::new(
+            dht_rec.owner().to_owned(),
+            dht_rec
+                .owner_secret()
+                .ok_or(Error::other("expected dht owner secret"))?
+                .to_owned(),
+        );
+        db.store_json(0, digest_key.as_slice(), dht_rec.key())
+            .await?;
+        db.store_json(1, digest_key.as_slice(), &dht_owner).await?;
+        Ok(dht_rec)
+    }
+
+    async fn write_header(&self, key: &ShareKey, index: &Index, header: &Header) -> Result<()> {
+        // Encode the header
+        let header_bytes = encode_header(&index, header.subkeys(), header.route_data())
+            .map_err(Error::internal_protocol)?;
+        debug!(header_length = header_bytes.len(), "writing header");
+
+        self.routing_context
+            .set_dht_value(key.to_owned(), 0, header_bytes, None)
+            .await?;
+        Ok(())
+    }
+
+    async fn write_index_bytes(&self, dht_key: &ShareKey, index_bytes: &[u8]) -> Result<()> {
+        let mut subkey = 1; // index starts at subkey 1 (header is subkey 0)
+        let mut offset = 0;
+        loop {
+            if offset > index_bytes.len() {
+                return Ok(());
+            }
+            let count = min(ValueData::MAX_LEN, index_bytes.len() - offset);
+            debug!(offset, count, "writing index");
+            self.routing_context
+                .set_dht_value(
+                    dht_key.to_owned(),
+                    subkey,
+                    index_bytes[offset..offset + count].to_vec(),
+                    None,
+                )
+                .await?;
+            subkey += 1;
+            offset += ValueData::MAX_LEN;
+        }
+    }
+
+    async fn read_header(&self, key: &ShareKey) -> Result<Header> {
+        let subkey_value = match self
+            .routing_context
+            .get_dht_value(key.to_owned(), 0, true)
+            .await?
+        {
+            Some(value) => value,
+            None => {
+                return Err(VeilidAPIError::KeyNotFound {
+                    key: key.to_owned(),
+                }
+                .into())
+            }
+        };
+        Ok(decode_header(subkey_value.data()).map_err(Error::remote_protocol)?)
+    }
+
+    async fn read_index(&self, key: &ShareKey, header: &Header, root: &Path) -> Result<Index> {
+        let mut index_bytes = vec![];
+        for i in 0..header.subkeys() {
+            let subkey_value = match self
+                .routing_context
+                .get_dht_value(key.to_owned(), (i + 1) as u32, true)
+                .await?
+            {
+                Some(value) => value,
+                None => {
+                    return Err(VeilidAPIError::KeyNotFound {
+                        key: key.to_owned(),
+                    }
+                    .into())
+                }
+            };
+            index_bytes.extend_from_slice(subkey_value.data());
+        }
+        Ok(
+            decode_index(root.to_path_buf(), header, index_bytes.as_slice())
+                .map_err(Error::remote_protocol)?,
+        )
+    }
+
+    fn release_prior_route(&self, prior_route: Option<Target>) {
+        match prior_route {
+            Some(Target::PrivateRoute(target)) => {
+                let _ = self.routing_context.api().release_private_route(target);
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Clone for VeilidPeer {
+    fn clone(&self) -> Self {
+        VeilidPeer {
+            routing_context: self.routing_context.clone(),
+            update_tx: self.update_tx.clone(),
+        }
+    }
+}
+
+impl Peer for VeilidPeer {
+    fn subscribe_veilid_update(&self) -> Receiver<VeilidUpdate> {
+        self.update_tx.subscribe()
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        if let Err(e) = self.routing_context.api().detach().await {
+            trace!(err = e.to_string(), "detach failed");
+        }
+        self.routing_context.api().attach().await?;
+        Ok(())
+    }
+
+    async fn shutdown(self) -> Result<()> {
+        self.routing_context.api().shutdown().await;
+        Ok(())
+    }
+
+    async fn announce(&mut self, index: &Index) -> Result<(ShareKey, Target, Header)> {
+        // Serialize index to index_bytes
+        let index_bytes = encode_index(index).map_err(Error::internal_protocol)?;
+        let (announce_route, route_data) = self.routing_context.api().new_private_route().await?;
+        let header = Header::from_index(index, index_bytes.as_slice(), route_data.as_slice());
+        let dht_rec = self.open_or_create_dht_record(&header).await?;
+        let dht_key = dht_rec.key().to_owned();
+        self.write_index_bytes(&dht_key, index_bytes.as_slice())
+            .await?;
+        self.write_header(&dht_key, &index, &header).await?;
+        Ok((dht_key, Target::PrivateRoute(announce_route), header))
+    }
+
+    async fn reannounce_route(
+        &mut self,
+        key: &ShareKey,
+        prior_route: Option<Target>,
+        index: &Index,
+        header: &Header,
+    ) -> Result<(Target, Header)> {
+        self.release_prior_route(prior_route);
+        let (announce_route, route_data) = self.routing_context.api().new_private_route().await?;
+        let header = header.with_route_data(route_data);
+        self.write_header(&key, &index, &header).await?;
+        Ok((Target::PrivateRoute(announce_route), header))
+    }
+
+    async fn resolve(&mut self, key: &ShareKey, root: &Path) -> Result<(Target, Header, Index)> {
+        let _ = self
+            .routing_context
+            .open_dht_record(key.to_owned(), None)
+            .await?;
+        let header = self.read_header(key).await?;
+        let index = self.read_index(key, &header, &root).await?;
+        let target = self
+            .routing_context
+            .api()
+            .import_remote_private_route(header.route_data().to_vec())?;
+        Ok((Target::PrivateRoute(target), header, index))
+    }
+
+    async fn reresolve_route(
+        &mut self,
+        key: &ShareKey,
+        prior_route: Option<Target>,
+    ) -> Result<(Target, Header)> {
+        self.release_prior_route(prior_route);
+        let header = self.read_header(key).await?;
+        let target = self
+            .routing_context
+            .api()
+            .import_remote_private_route(header.route_data().to_vec())?;
+        Ok((Target::PrivateRoute(target), header))
+    }
+
+    async fn request_block(
+        &mut self,
+        target: Target,
+        piece: usize,
+        block: usize,
+    ) -> Result<Vec<u8>> {
+        let block_req = BlockRequest {
+            piece: piece as u32,
+            block: block as u8,
+        };
+        let block_req_bytes = encode_block_request(&block_req).map_err(Error::internal_protocol)?;
+        let resp_bytes = self
+            .routing_context
+            .app_call(target, block_req_bytes)
+            .await?;
+        Ok(resp_bytes)
+    }
+
+    async fn reply_block_contents(&mut self, call_id: OperationId, contents: &[u8]) -> Result<()> {
+        self.routing_context
+            .api()
+            .app_call_reply(call_id, contents.to_vec())
+            .await?;
+        Ok(())
+    }
+}

--- a/distrans-peer/src/proto/mod.rs
+++ b/distrans-peer/src/proto/mod.rs
@@ -148,6 +148,22 @@ impl Header {
         }
     }
 
+    pub fn from_index(index: &Index, index_bytes: &[u8], route_data: &[u8]) -> Header {
+        Header::new(
+            index.payload().digest().try_into().unwrap(),
+            index.payload().length(),
+            ((index_bytes.len() / 32768)
+                + if (index_bytes.len() % 32768) > 0 {
+                    1
+                } else {
+                    0
+                })
+            .try_into()
+            .unwrap(),
+            route_data,
+        )
+    }
+
     pub fn payload_digest(&self) -> [u8; 32] {
         self.payload_digest.clone()
     }

--- a/distrans-peer/src/tests/mod.rs
+++ b/distrans-peer/src/tests/mod.rs
@@ -1,0 +1,14 @@
+use std::io::Write;
+
+use tempfile::NamedTempFile;
+
+mod stub_peer;
+
+pub use stub_peer::StubPeer;
+
+pub fn temp_file(pattern: u8, count: usize) -> NamedTempFile {
+    let mut tempf = NamedTempFile::new().expect("temp file");
+    let contents = vec![pattern; count];
+    tempf.write(contents.as_slice()).expect("write temp file");
+    tempf
+}

--- a/distrans-peer/src/tests/stub_peer.rs
+++ b/distrans-peer/src/tests/stub_peer.rs
@@ -1,0 +1,123 @@
+use std::{
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+use distrans_fileindex::Index;
+use tokio::sync::broadcast::{self, Receiver, Sender};
+use veilid_core::{OperationId, Target, VeilidUpdate};
+
+use crate::{error::Result, peer::ShareKey};
+use crate::{proto::Header, Peer};
+
+pub struct StubPeer {
+    pub update_tx: Sender<VeilidUpdate>,
+    pub reset_result: Arc<Mutex<dyn Fn() -> Result<()> + Send + 'static>>,
+    pub shutdown_result: Arc<Mutex<dyn Fn() -> Result<()> + Send + 'static>>,
+    pub announce_result:
+        Arc<Mutex<dyn Fn() -> Result<(ShareKey, Target, Header)> + Send + 'static>>,
+    pub reannounce_route_result: Arc<Mutex<dyn Fn() -> Result<(Target, Header)> + Send + 'static>>,
+    pub resolve_result: Arc<Mutex<dyn Fn() -> Result<(Target, Header, Index)> + Send + 'static>>,
+    pub reresolve_route_result: Arc<Mutex<dyn Fn() -> Result<(Target, Header)> + Send + 'static>>,
+    pub request_block_result: Arc<Mutex<dyn Fn() -> Result<Vec<u8>> + Send + 'static>>,
+    pub reply_block_contents_result: Arc<Mutex<dyn Fn() -> Result<()> + Send + 'static>>,
+}
+
+impl StubPeer {
+    pub fn new() -> Self {
+        let (update_tx, _) = broadcast::channel(16);
+        StubPeer {
+            update_tx,
+            reset_result: Arc::new(Mutex::new(|| panic!("unexpected call to reset"))),
+            shutdown_result: Arc::new(Mutex::new(|| panic!("unexpected call to shutdown"))),
+            announce_result: Arc::new(Mutex::new(|| panic!("unexpected call to announce"))),
+            reannounce_route_result: Arc::new(Mutex::new(|| {
+                panic!("unexpected call to reannounce_route")
+            })),
+            resolve_result: Arc::new(Mutex::new(|| panic!("unexpected call to resolve"))),
+            reresolve_route_result: Arc::new(Mutex::new(|| {
+                panic!("unexpected call to reresolve_route")
+            })),
+            request_block_result: Arc::new(Mutex::new(|| {
+                panic!("unexpected call to request_block")
+            })),
+            reply_block_contents_result: Arc::new(Mutex::new(|| {
+                panic!("unexpected call to reply_block_contents")
+            })),
+        }
+    }
+}
+
+impl Peer for StubPeer {
+    fn subscribe_veilid_update(&self) -> Receiver<VeilidUpdate> {
+        self.update_tx.subscribe()
+    }
+
+    async fn reset(&mut self) -> Result<()> {
+        (*(self.reset_result.lock().unwrap()))()
+    }
+
+    async fn shutdown(self) -> Result<()> {
+        (*(self.shutdown_result.lock().unwrap()))()
+    }
+
+    async fn announce(&mut self, _index: &Index) -> Result<(ShareKey, Target, Header)> {
+        (*(self.announce_result.lock().unwrap()))()
+    }
+
+    async fn reannounce_route(
+        &mut self,
+        _key: &ShareKey,
+        _prior_route: Option<Target>,
+        _index: &Index,
+        _header: &Header,
+    ) -> Result<(Target, Header)> {
+        (*(self.reannounce_route_result.lock().unwrap()))()
+    }
+
+    async fn resolve(&mut self, _key: &ShareKey, _root: &Path) -> Result<(Target, Header, Index)> {
+        (*(self.resolve_result.lock().unwrap()))()
+    }
+
+    async fn reresolve_route(
+        &mut self,
+        _key: &ShareKey,
+        _prior_route: Option<Target>,
+    ) -> Result<(Target, Header)> {
+        (*(self.reresolve_route_result.lock().unwrap()))()
+    }
+
+    async fn request_block(
+        &mut self,
+        _target: Target,
+        _piece: usize,
+        _block: usize,
+    ) -> Result<Vec<u8>> {
+        (*(self.request_block_result.lock().unwrap()))()
+    }
+
+    async fn reply_block_contents(
+        &mut self,
+        _call_id: OperationId,
+        _contents: &[u8],
+    ) -> Result<()> {
+        (*(self.reply_block_contents_result.lock().unwrap()))()
+    }
+}
+
+impl Clone for StubPeer {
+    fn clone(&self) -> Self {
+        StubPeer {
+            update_tx: self.update_tx.clone(),
+            reset_result: self.reset_result.clone(),
+            shutdown_result: self.shutdown_result.clone(),
+            announce_result: self.announce_result.clone(),
+            reannounce_route_result: self.reannounce_route_result.clone(),
+            resolve_result: self.resolve_result.clone(),
+            reresolve_route_result: self.reresolve_route_result.clone(),
+
+            request_block_result: self.request_block_result.clone(),
+            reply_block_contents_result: self.reply_block_contents_result.clone(),
+        }
+    }
+}

--- a/src/bin/stress.rs
+++ b/src/bin/stress.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use distrans_peer::{other_err, veilid_config, Error, Result};
+use distrans_peer::{veilid_config, Error, Result};
 
 use clap::{command, Parser};
 use flume::{unbounded, Receiver, Sender};
@@ -22,8 +22,8 @@ use tracing::{debug, error, info, trace, warn};
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::prelude::*;
 use veilid_core::{
-    DHTRecordDescriptor, FromStr, KeyPair, RouteId, RoutingContext, Sequencing,
-    Target, TypedKey, VeilidUpdate,
+    DHTRecordDescriptor, FromStr, KeyPair, RouteId, RoutingContext, Sequencing, Target, TypedKey,
+    VeilidUpdate,
 };
 
 // This utility seeks to answer some basic questions worth answering before
@@ -167,7 +167,7 @@ impl App {
                     trace!(update = format!("{:?}", u));
                 }
                 Err(e) => {
-                    return Err(Error::Other(e.to_string()));
+                    return Err(Error::other(e.to_string()));
                 }
             };
         }
@@ -209,7 +209,7 @@ impl App {
             dht_rec.owner().to_owned(),
             dht_rec
                 .owner_secret()
-                .ok_or(other_err("expected dht owner secret"))?
+                .ok_or(Error::other("expected dht owner secret"))?
                 .to_owned(),
         );
         db.store_json(0, &[], dht_rec.key()).await?;
@@ -296,7 +296,7 @@ impl App {
                                 .app_call(Target::PrivateRoute(rid), msg),
                         )
                         .await
-                        .map_err(other_err)??;
+                        .map_err(Error::other)??;
                         let delta = t0.elapsed();
                         debug!(sent = msg_len, received = resp.len());
                         counter!("bytes_sent").increment(msg_len as u64);
@@ -330,7 +330,7 @@ impl App {
                     res = callee.updates.recv_async() => {
                         let update = match res {
                             Ok(update) => update,
-                            Err(e) => return Err(other_err(e)),
+                            Err(e) => return Err(Error::other(e)),
                         };
                         match update {
                             VeilidUpdate::AppCall(app_call) => {


### PR DESCRIPTION
Consolidated retry logic and error handling with a more intentional goal-seeking state machine approach.

Introducing a Peer trait abstraction which may be used to fetch and seed content, over an implementation which automatically deals with network conditions.

Modeling the application-layer as a trait enables more scenario testing with mocks.

- [x] unit test ResilientPeer
- [x] unit test Seeder and Fetcher

Deferred:
- [ ] improve TUI integration