### PR TITLE
fix: rename subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,25 @@
 
 Distrans (distribution and transfer) sends and receives file content anonymously over the [Veilid](https://veilid.com) network.
 
-# Install
+# Usage
 
-## Install binary release
+`distrans seed <file>` indexes and seeds a file , displaying the dht key which can be used to fetch it.
+
+`distrans fetch <dht key> [directory]` fetches a file while it's being seeded (defaults to current directory).
+
+Similar to bittorrent, distrans cannot fetch a file unless it's being seeded by a peer.
+
+See `distrans --help` for more options.
+
+## Try it!
+
+Try fetching a test file with `distrans fetch VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M`.
+
+# Install
 
 Install a [binary release](https://github.com/cmars/distrans/releases) on Linux, macOS or Windows.
 
-## Install Rust crate
+## Rust crate
 
 Install the crate with `cargo install distrans`.
 
@@ -24,9 +36,9 @@ Debian Bookworm needs `apt-get install build-essential libssl-dev pkg-config`.
 
 Others may be similar.
 
-## Install Nix flake
+## Nix flake
 
-Run with `nix run github:cmars/distrans`.
+Run distrans on Nix with `nix run github:cmars/distrans`.
 
 Add this flake (`github:cmars/distrans`) as an input to your home manager flake.
 
@@ -34,29 +46,33 @@ Or add the default package to a legacy `home.nix` with something like:
 
     (builtins.getFlake "github:cmars/distrans").packages.x86_64-linux.default
 
-# Usage
+# Plans
 
-`distrans post <file>` indexes and seeds a file, displaying the dht key where it can be downloaded.
+What's on the roadmap for a 1.0 release.
 
-`distrans get <dht key> [directory]` downloads a posted file (defaults to current directory).
+## Trackers
 
-See `distrans --help` for more options.
+Trackers will enable a swarm of distrans peers to operate more like bittorrent, where blocks may be simultaneously seeded and fetched.
 
-## Try it!
+## Multi-file shares
 
-Try fetching a test file with `distrans get VLD0:cCHB85pEaV4bvRfywxnd2fRNBScR64UaJC8hoKzyr3M`.
+The distrans wire protocol and indexing structures support multi-file shares, but this hasn't been fully implemented yet.
 
-## Troubleshooting
+# Troubleshooting
 
-### Clock skew
+## Clock skew
 
 Distrans operates an embedded Veilid node, which requires a synchronized local clock. Clock skew can prevent distrans from connecting to the Veilid network.
 
-### Debug logging
+## Debug logging
 
 Logging can be configured with the [RUST_LOG environment variable](https://docs.rs/env_logger/latest/env_logger/#enabling-logging).
 
 `RUST_LOG=debug` will enable all debug-level logging in distrans as well as veilid-core, which may be useful for troubleshooting low-level Veilid network problems and reporting issues.
+
+## Issues
+
+When opening an issue, note the OS type, OS release version, distrans version, and steps to reproduce. Any logs you can attach may help.
 
 # Development
 
@@ -76,8 +92,3 @@ Branches and releases are regularly mirrored to [Gitlab](https://gitlab.com/cmar
 
 Open an issue and ask before picking up a branch and proposing, for best results.
 
-# Roadmap
-
-See [project plans](https://github.com/users/cmars/projects/1/views/1) for short-term plans and contribution ideas.
-
-Long-term: Full duplex peer downloading and uploading. Trackers and swarms.

--- a/src/app.rs
+++ b/src/app.rs
@@ -265,7 +265,7 @@ impl App {
         });
 
         let result = match self.cli.commands {
-            Commands::Get {
+            Commands::Fetch {
                 dht_key: ref share_key,
                 ref root,
             } => {
@@ -286,7 +286,7 @@ impl App {
                 tx.send_async(State::FetchComplete).await?;
                 Ok(())
             }
-            Commands::Post { ref file } => {
+            Commands::Seed { ref file } => {
                 tx.send_async(State::IndexingFile {
                     file: file.to_owned(),
                 })

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,11 +29,11 @@ impl Cli {
             return Ok(s.to_owned());
         }
         match self.commands {
-            Commands::Get {
+            Commands::Fetch {
                 ref dht_key,
                 ref root,
             } => self.state_dir_for(format!("get:{}:{}", dht_key, root)),
-            Commands::Post { ref file } => self.state_dir_for(format!("post:{}", file.to_owned())),
+            Commands::Seed { ref file } => self.state_dir_for(format!("seed:{}", file.to_owned())),
             _ => Err(Error::msg("invalid command")),
         }
     }
@@ -66,12 +66,12 @@ impl Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    Get {
+    Fetch {
         dht_key: String,
         #[arg(default_value = ".")]
         root: String,
     },
-    Post {
+    Seed {
         file: String,
     },
     Version,


### PR DESCRIPTION
Subcommands were too HTTP-ish. Post doesn't really convey "you're seeding this content and if you stop others can't get it at the DHT key". Get is OK but going with fetch because that's so fetch.