### PR TITLE
fix: fetcher cancellation

### DIFF
--- a/distrans-peer/src/error.rs
+++ b/distrans-peer/src/error.rs
@@ -139,6 +139,9 @@ impl Error {
     pub fn internal_protocol(err: proto::Error) -> Error {
         Error::InternalProtocol(err)
     }
+    pub fn cancelled<E>(_err: E) -> Error {
+        Error::Fault(Unexpected::Cancelled)
+    }
 
     pub fn is_route_invalid(err: &Error) -> bool {
         if let Error::Node { state, err: _ } = err {
@@ -186,6 +189,7 @@ pub enum Unexpected {
     Utf8(std::str::Utf8Error),
     IntOverflow(TryFromIntError),
     SliceSize(TryFromSliceError),
+    Cancelled,
     Other(String),
 }
 
@@ -196,6 +200,7 @@ impl fmt::Display for Unexpected {
             Unexpected::Utf8(e) => write!(f, "utf8 encoding failed: {}", e),
             Unexpected::IntOverflow(e) => write!(f, "integer overflow: {}", e),
             Unexpected::SliceSize(e) => write!(f, "unexpected slice size: {}", e),
+            Unexpected::Cancelled => write!(f, "cancelled"),
             Unexpected::Other(e) => write!(f, "{}", e),
         }
     }

--- a/distrans-peer/src/lib.rs
+++ b/distrans-peer/src/lib.rs
@@ -10,7 +10,7 @@ use std::{path::PathBuf, sync::Arc};
 use tokio::sync::broadcast::{self, Receiver, Sender};
 use veilid_core::{RoutingContext, Sequencing, VeilidUpdate};
 
-pub use error::{Error, Result};
+pub use error::{Error, Result, Unexpected};
 pub use fetcher::Fetcher;
 pub use peer::{Peer, PeerState, ResilientPeer, VeilidPeer};
 pub use seeder::Seeder;

--- a/src/app.rs
+++ b/src/app.rs
@@ -186,13 +186,20 @@ impl App {
         fetch_progress.enable_steady_tick(Duration::from_millis(250));
         fetch_progress.set_message("Fetching share");
 
-        fetcher.fetch(cancel.clone()).await?;
-        fetch_progress.finish_with_message("✅ Fetch complete");
+        let fetch_result = fetcher.fetch(cancel.clone()).await;
+        let msg = match fetch_result {
+            Ok(()) => "✅ Fetch complete",
+            Err(distrans_peer::Error::Fault(distrans_peer::Unexpected::Cancelled)) => {
+                "❌ Fetch cancelled"
+            }
+            Err(_) => "❌ Fetch failed",
+        };
+        fetch_progress.finish_with_message(msg);
 
         cancel.cancel();
         peer.shutdown().await?;
 
-        let _ = m.println("✅ Fetch complete");
+        let _ = m.println(msg);
         Ok(())
     }
 


### PR DESCRIPTION
When cancelling the app (ctrl-c signal or equivalent) the fetcher was failing to shut down, and getting stuck in a retry loop. Not retry in ResilientPeer, but requeuing block fetch requests.

This introduces a proper cancel error fault type, gracefully exiting the fetcher on cancellation.

Drive-by: improve the fetch progress / final shutdown message.