### PR TITLE
fix: display fetch download directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.3.2"
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.15.1"
 # CI backends to support
-ci = ["github"]
+ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell", "npm", "homebrew", "msi"]
 # Target platforms to build apps for (Rust target-triple syntax)
@@ -28,7 +28,7 @@ targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-
 # Publish jobs to run in CI
 pr-run-mode = "upload"
 # Where to host releases
-hosting = ["github"]
+hosting = "github"
 # Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci", "msi"]
 # A GitHub repo to push Homebrew formulas to
@@ -39,6 +39,8 @@ windows-archive = ".tar.gz"
 unix-archive = ".tar.gz"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew", "npm"]
+# Whether to install an updater program
+install-updater = false
 
 [workspace.metadata.release]
 shared-version = true

--- a/distrans-cli/src/app.rs
+++ b/distrans-cli/src/app.rs
@@ -1,4 +1,7 @@
-use std::time::Duration;
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use color_eyre::{eyre::Error, owo_colors::OwoColorize, Result};
@@ -172,7 +175,7 @@ impl App {
         fetch_progress.set_message(format!(
             "Fetching {} into {}",
             fetcher.file().bold().bright_cyan(),
-            root
+            PathBuf::from(root).canonicalize()?.to_string_lossy()
         ));
         let fetch_progress_spinner = fetch_progress.clone();
 


### PR DESCRIPTION
When fetching a file into cwd, resolve that cwd to an absolute path.

Fixes #101

Drive-by: update cargo-dist config, trying to fix release PR automation.