### PR TITLE
feat: resume a prior partially fetched file

### DIFF
--- a/distrans-cli/src/app.rs
+++ b/distrans-cli/src/app.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::{path::PathBuf, time::Duration};
 
 use backoff::{backoff::Backoff, ExponentialBackoff};
 use color_eyre::{eyre::Error, owo_colors::OwoColorize, Result};
@@ -187,7 +184,7 @@ impl App {
         fetch_progress_bar.set_message("Fetching blocks");
         let verify_progress_bar = m.add(ProgressBar::new(0u64));
         verify_progress_bar.set_style(self.bar_style.clone());
-        verify_progress_bar.set_message("Verifying blocks");
+        verify_progress_bar.set_message("Verifying pieces");
         spawn(async move {
             loop {
                 select! {


### PR DESCRIPTION
Index the file-on-disk and compare pieces we have with pieces we want before enqueuing them for fetch.

This will resume a fetch that was interrupted, avoiding wasting time and bandwidth re-fetching pieces we already have.

This implementation is single-file-naive, noted where this will need to change.