### PR TITLE
fix: node listen address port conflict

### DIFF
--- a/distrans-cli/src/app.rs
+++ b/distrans-cli/src/app.rs
@@ -8,6 +8,7 @@ use tokio::{select, spawn, time::sleep};
 use tokio_util::sync::CancellationToken;
 
 use distrans_peer::{new_routing_context, Fetcher, Observable, Peer, PeerState, Seeder, Veilid};
+use tracing::error;
 
 use crate::{cli::Commands, initialize_stderr_logging, initialize_ui_logging, Cli};
 
@@ -106,6 +107,7 @@ impl App {
             let result = peer.reset().await;
             if let Err(e) = result {
                 if !e.is_resetable() {
+                    error!(err = format!("{}", e), "not resetable");
                     cancel.cancel();
                     return Err(e.into());
                 }
@@ -118,8 +120,9 @@ impl App {
                         );
                     }
                 }
+            } else {
+                break;
             }
-            break;
         }
 
         let ctrl_c_cancel = cancel.clone();

--- a/distrans-peer/src/error.rs
+++ b/distrans-peer/src/error.rs
@@ -183,7 +183,7 @@ impl Error {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NodeState {
     APINotStarted,
     NetworkNotAvailable,
@@ -195,8 +195,8 @@ pub enum NodeState {
 }
 
 impl NodeState {
-    pub fn is_connected(node_state: &Self) -> bool {
-        *node_state == NodeState::Connected
+    pub fn is_connected(&self) -> bool {
+        *self == NodeState::Connected
     }
 }
 

--- a/distrans-peer/src/veilid_config.rs
+++ b/distrans-peer/src/veilid_config.rs
@@ -1,4 +1,13 @@
+use std::env;
+
 use veilid_core::{ConfigCallbackReturn, FourCC, TypedKeyGroup, TypedSecretGroup, VeilidAPIError};
+
+pub fn node_addr() -> Option<String> {
+    match env::var("NODE_ADDR") {
+        Ok(val) => Some(val),
+        Err(_) => None,
+    }
+}
 
 pub fn callback(state_dir: String, key: String) -> ConfigCallbackReturn {
     match key.as_str() {
@@ -80,12 +89,12 @@ pub fn callback(state_dir: String, key: String) -> ConfigCallbackReturn {
         "network.application.http.url" => Ok(Box::new(Option::<String>::None)),
         "network.protocol.udp.enabled" => Ok(Box::new(true)),
         "network.protocol.udp.socket_pool_size" => Ok(Box::new(16u32)),
-        "network.protocol.udp.listen_address" => Ok(Box::new(":5150".to_owned())),
+        "network.protocol.udp.listen_address" => Ok(Box::new(node_addr().unwrap_or("".to_owned()))),
         "network.protocol.udp.public_address" => Ok(Box::new(Option::<String>::None)),
         "network.protocol.tcp.connect" => Ok(Box::new(true)),
         "network.protocol.tcp.listen" => Ok(Box::new(true)),
         "network.protocol.tcp.max_connections" => Ok(Box::new(32u32)),
-        "network.protocol.tcp.listen_address" => Ok(Box::new(":5150".to_owned())),
+        "network.protocol.tcp.listen_address" => Ok(Box::new(node_addr().unwrap_or("".to_owned()))),
         "network.protocol.tcp.public_address" => Ok(Box::new(Option::<String>::None)),
         "network.protocol.ws.connect" => Ok(Box::new(false)),
         "network.protocol.ws.listen" => Ok(Box::new(false)),

--- a/examples/fly.io/Dockerfile
+++ b/examples/fly.io/Dockerfile
@@ -23,5 +23,6 @@ VOLUME /state
 ENV STATE_DIR=/state
 
 ENV RUST_LOG="veilid_core=debug,distrans=debug"
+ENV NODE_ADDR=":5150"
 
 ENTRYPOINT ["/distrans", "seed", "/share/secure-envelopes.png"]


### PR DESCRIPTION
Listening on :5150 unconditionally prevents running multiple instances of distrans, which should be allowed.

Only set up the node listen address if NODE_ADDR is set.

Configure the fly.io docker image to set it, so that the example workload continues to support the network.