### PR TITLE
chore: disable github workflow fragment

### DIFF
--- a/.github/workflows/build-setup.yml
+++ b/.github/workflows/build-setup.yml
@@ -1,2 +1,0 @@
-- name: Customize environment variables
-  run: echo "RUSTFLAGS='--cfg tokio_unstable'" >> $GITHUB_ENV

--- a/.github/workflows/build-setup.yml.todo
+++ b/.github/workflows/build-setup.yml.todo
@@ -1,0 +1,4 @@
+### TODO: rename & uncomment once cargo-dist 0.20.0 releases
+### See top-level Cargo.toml [workspace.metadata.dist] for details
+#- name: Customize environment variables
+#  run: echo "RUSTFLAGS='--cfg tokio_unstable'" >> $GITHUB_ENV


### PR DESCRIPTION
Config fragment in workflows is causing harmless but annoying action failures.

Leave a note to remind when it can be re-enabled w/cargo-dist that supports it.