### PR TITLE
chore: fly.io example updates

### DIFF
--- a/examples/fly.io/Dockerfile
+++ b/examples/fly.io/Dockerfile
@@ -22,7 +22,10 @@ COPY --from=builder /src/examples/fly.io/secure-envelopes.png .
 VOLUME /state
 ENV STATE_DIR=/state
 
-ENV RUST_LOG="veilid_core=debug,distrans=debug"
+ENV RUST_LOG="veilid_core=error,distrans=debug"
 ENV NODE_ADDR=":5150"
+
+EXPOSE 5150/udp
+EXPOSE 5150/tcp
 
 ENTRYPOINT ["/distrans", "seed", "/share/secure-envelopes.png"]

--- a/fly.toml
+++ b/fly.toml
@@ -4,7 +4,7 @@
 #
 
 app = 'distrans-seed-demofile'
-primary_region = 'dfw'
+primary_region = 'ord'
 
 [build]
   dockerfile = 'examples/fly.io/Dockerfile'


### PR DESCRIPTION
Expose ports in container build.
Set region to ord.
Set veilid-core log level to error, debug is chatty.