### PR TITLE
fix: fetch hangs on complete file

### DIFF
--- a/distrans-peer/src/fetcher.rs
+++ b/distrans-peer/src/fetcher.rs
@@ -151,6 +151,9 @@ impl<P: Peer + Clone + 'static> Fetcher<P> {
         let mut verify_progress_rx = self.verify_progress_tx.subscribe();
         loop {
             select! {
+                _ = done.cancelled() => {
+                    break;
+                }
                 verify_status = verify_tasks.join_next() => {
                     if verify_rx.is_empty() {
                         // If we verified all the blocks, forget any prior
@@ -270,7 +273,7 @@ impl<P: Peer + Clone + 'static> Fetcher<P> {
     ) -> Result<()> {
         let mut fh_map: HashMap<usize, File> = HashMap::new();
         loop {
-            tokio::select! {
+            select! {
                 recv_fetch = fetch_block_rx.recv_async() => {
                     let fetch = match recv_fetch {
                         Ok(fetch) => fetch,
@@ -398,7 +401,7 @@ impl<P: Peer + Clone + 'static> Fetcher<P> {
         let mut piece_states: HashMap<(usize, usize), PieceState> = HashMap::new();
         let mut verified_pieces = 0;
         loop {
-            tokio::select! {
+            select! {
                 recv_verify = verify_rx.recv_async() => {
                     // select on verify receiver
                     let mut to_verify = match recv_verify {

--- a/distrans-peer/src/lib.rs
+++ b/distrans-peer/src/lib.rs
@@ -5,7 +5,7 @@ mod proto;
 mod seeder;
 pub mod veilid_config;
 
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 use tokio::sync::broadcast::{self, Receiver, Sender};
 use veilid_core::{RoutingContext, VeilidUpdate};


### PR DESCRIPTION
If fetch is run on an already complete and verified file, the fetcher loop was failing to exit. Selecting on done cancellation catches this edge case.