### PR TITLE
fix: fetcher error recovery, connection state

### DIFF
--- a/stigmerge-peer/examples/syncer.rs
+++ b/stigmerge-peer/examples/syncer.rs
@@ -232,6 +232,7 @@ async fn run<T: Node + Sync + Send + 'static>(node: T) -> Result<()> {
         share_target_rx,
         peer_resolver: peer_resolver_op,
         discovered_peers_rx,
+        update_rx: node.subscribe_veilid_update(),
     };
 
     // Set up seeder
@@ -244,7 +245,7 @@ async fn run<T: Node + Sync + Send + 'static>(node: T) -> Result<()> {
     let seeder_op = Operator::new(
         cancel.clone(),
         seeder,
-        WithVeilidConnection::new(node.clone(), conn_state),
+        WithVeilidConnection::new(node.clone(), conn_state.clone()),
     );
 
     // Create and run fetcher
@@ -253,7 +254,7 @@ async fn run<T: Node + Sync + Send + 'static>(node: T) -> Result<()> {
     info!("Starting fetch...");
 
     // Run the fetcher until completion
-    let fetcher_task = spawn(fetcher.run(cancel.clone()));
+    let fetcher_task = spawn(fetcher.run(cancel.clone(), conn_state));
 
     info!("Seeding until ctrl-c...");
 

--- a/stigmerge-peer/src/actor.rs
+++ b/stigmerge-peer/src/actor.rs
@@ -282,7 +282,7 @@ pub struct WithVeilidConnection<N> {
 }
 
 pub struct ConnectionState {
-    connected: watch::Sender<bool>,
+    pub(crate) connected: watch::Sender<bool>,
 }
 
 impl ConnectionState {
@@ -368,7 +368,7 @@ impl<N: Node> WithVeilidConnection<N> {
     }
 }
 
-const MAX_TRANSIENT_RETRIES: u8 = 5;
+pub(crate) const MAX_TRANSIENT_RETRIES: u8 = 5;
 
 impl<
         A: Actor<Request: Send + Sync + 'static, Response: Send + Sync + 'static>
@@ -440,7 +440,8 @@ impl<
                             }
                             {
                                 if let Ok(st) = state.try_lock() {
-                                    info!("marking disconnected");
+                                    info!("marking disconnected, resetting");
+                                    self.node.reset().await?;
                                     st.disconnect();
                                     exp_backoff.reset();
                                     retries = 0;

--- a/stigmerge/src/app.rs
+++ b/stigmerge/src/app.rs
@@ -300,6 +300,7 @@ impl App {
             share_target_rx,
             peer_resolver: peer_resolver_op,
             discovered_peers_rx,
+            update_rx: node.subscribe_veilid_update(),
         };
 
         // Create and run fetcher
@@ -307,7 +308,7 @@ impl App {
 
         let fetcher = Fetcher::new(node.clone(), share.clone(), fetcher_clients);
         self.add_fetch_progress(&cancel, &mut tasks, fetcher.subscribe_fetcher_status())?;
-        let fetcher_task = spawn(fetcher.run(cancel.clone()));
+        let fetcher_task = spawn(fetcher.run(cancel.clone(), conn_state.clone()));
 
         // Set up seeder
         let seeder_clients = seeder::Clients {


### PR DESCRIPTION
When no peers are available to fetch from, requeue the block request. These were getting dropped, preventing interrupted fetches from completing properly.

Add connection state awareness to fetch loop. This will get further improvements in followups and eventually, we'll want to refactor to use WithVeilidConnection or some common logic with that runner.

Fetcher::fetch can be restarted on reconnect.

Minor refactoring of Fetcher::Status methods to get fetch vs verify positions.