### PR TITLE
fix: fetcher done on verification complete

### DIFF
--- a/stigmerge-peer/src/actor.rs
+++ b/stigmerge-peer/src/actor.rs
@@ -141,7 +141,7 @@ impl<Req: Respondable + Send + Sync + 'static> Operator<Req> {
         runner: R,
         n: usize,
     ) -> Self {
-        let (request_tx, request_rx) = flume::unbounded();
+        let (request_tx, request_rx) = flume::bounded(n * 2);
         let mut tasks = JoinSet::new();
         for _ in 0..n {
             let mut task_runner = runner.clone();

--- a/stigmerge/src/app.rs
+++ b/stigmerge/src/app.rs
@@ -405,7 +405,7 @@ impl App {
                             }
                             fetcher::Status::FetchProgress { fetch_position, fetch_length, verify_position, verify_length } => {
                                 fetch_progress.set_message("Fetching ");
-                                fetch_progress.set_position(fetch_position);
+                                fetch_progress.set_position(if fetch_position > 0 { fetch_position.try_into().unwrap() } else { 0 });
                                 fetch_progress.set_length(fetch_length);
                                 verify_progress.set_message("Verifying");
                                 verify_progress.set_position(verify_position);


### PR DESCRIPTION
piece_verifier tracks verified pieces rather than pending ones, which can be fickle as pieces may get refetched.

Simplify fetcher status updates, eliminate local state vars that could drift.

Harden status against going temporarily negative.

Limit clone pool runner request channel to N*2, as a basic form of backpressure on excessive fetch errors.