### PR TITLE
fix: fetcher reset logic

### DIFF
--- a/stigmerge-peer/examples/fetch_block.rs
+++ b/stigmerge-peer/examples/fetch_block.rs
@@ -181,7 +181,7 @@ async fn main() -> std::result::Result<(), Error> {
                 let delay = fetch_backoff
                     .next_backoff()
                     .ok_or(anyhow::anyhow!("out of retries"))?;
-                warn!("Failed to fetch block: {}, delaying {:?}", err, delay);
+                warn!(?err, ?delay, "failed to fetch block");
                 tokio::time::sleep(delay).await;
             }
         }

--- a/stigmerge-peer/examples/syncer.rs
+++ b/stigmerge-peer/examples/syncer.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
     let res = run(node.clone()).await;
     let _ = node.shutdown().await;
     if let Err(e) = res {
-        error!(err = e.to_string());
+        error!(err = ?e);
         return Err(e);
     }
     Ok(())

--- a/stigmerge-peer/src/have_resolver.rs
+++ b/stigmerge-peer/src/have_resolver.rs
@@ -244,7 +244,7 @@ impl<P: Node> Actor for HaveResolver<P> {
                         if let Some(have_map_ref) = header.have_map() {
                             self.have_to_share_map.remove(have_map_ref.key());
                             if let Err(e) = self.node.cancel_watch(have_map_ref.key()).await {
-                                warn!("cancel watch: {}", e);
+                                warn!(err = ?e, "cancel watch");
                             }
                         }
                         (

--- a/stigmerge-peer/src/lib.rs
+++ b/stigmerge-peer/src/lib.rs
@@ -55,7 +55,7 @@ pub async fn new_routing_context_from_config(
     // Configure Veilid core
     let update_callback = Arc::new(move |change: VeilidUpdate| {
         if let Err(e) = update_tx.send(change) {
-            warn!("dispatching veilid update: {:?}", e);
+            warn!(err = ?e, "dispatching veilid update");
         }
     });
 

--- a/stigmerge-peer/src/node/veilid.rs
+++ b/stigmerge-peer/src/node/veilid.rs
@@ -3,7 +3,8 @@ use std::{cmp::min, path::Path, sync::Arc};
 use tokio::sync::{broadcast, RwLock};
 use tracing::{trace, warn};
 use veilid_core::{
-    DHTRecordDescriptor, DHTSchema, KeyPair, OperationId, RoutingContext, Sequencing, Stability, Target, ValueData, ValueSubkeyRangeSet, VeilidAPIError, VeilidUpdate, VALID_CRYPTO_KINDS
+    DHTRecordDescriptor, DHTSchema, KeyPair, OperationId, RoutingContext, Sequencing, Stability,
+    Target, ValueData, ValueSubkeyRangeSet, VeilidAPIError, VeilidUpdate, VALID_CRYPTO_KINDS,
 };
 
 use stigmerge_fileindex::{FileSpec, Index, PayloadPiece, PayloadSpec};
@@ -283,11 +284,14 @@ impl Node for Veilid {
         let rc = self.routing_context.read().await;
         // Serialize index to index_bytes
         let index_bytes = index.encode()?;
-        let (announce_route, route_data) = rc.api().new_custom_private_route(
-            &VALID_CRYPTO_KINDS,
-            Stability::LowLatency,
-            Sequencing::NoPreference,
-        ).await?;
+        let (announce_route, route_data) = rc
+            .api()
+            .new_custom_private_route(
+                &VALID_CRYPTO_KINDS,
+                Stability::LowLatency,
+                Sequencing::NoPreference,
+            )
+            .await?;
         let mut header = Header::from_index(index, index_bytes.as_slice(), route_data.as_slice());
 
         let (have_map_key, have_map_subkeys) =
@@ -323,11 +327,14 @@ impl Node for Veilid {
         trace!(key = key.to_string());
         let rc = self.routing_context.read().await;
         self.release_prior_route(&rc, prior_route).await;
-        let (announce_route, route_data) = rc.api().new_custom_private_route(
-            &VALID_CRYPTO_KINDS,
-            Stability::LowLatency,
-            Sequencing::NoPreference,
-        ).await?;
+        let (announce_route, route_data) = rc
+            .api()
+            .new_custom_private_route(
+                &VALID_CRYPTO_KINDS,
+                Stability::LowLatency,
+                Sequencing::NoPreference,
+            )
+            .await?;
         let header = header.with_route_data(route_data);
         self.write_header(&rc, &key, &header).await?;
         Ok((Target::PrivateRoute(announce_route), header))

--- a/stigmerge-peer/src/share_announcer.rs
+++ b/stigmerge-peer/src/share_announcer.rs
@@ -2,7 +2,10 @@ use std::{fmt, time::Duration};
 
 use anyhow::Context;
 use stigmerge_fileindex::Index;
-use tokio::{select, time::{interval, MissedTickBehavior}};
+use tokio::{
+    select,
+    time::{interval, MissedTickBehavior},
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, trace};
 use veilid_core::{Target, TypedRecordKey, VeilidUpdate};

--- a/stigmerge-peer/src/share_resolver.rs
+++ b/stigmerge-peer/src/share_resolver.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use stigmerge_fileindex::Index;
 use tokio::{select, sync::broadcast};
 use tokio_util::sync::CancellationToken;
-use tracing::{info, trace, warn};
+use tracing::{trace, warn};
 use veilid_core::{Target, TypedRecordKey, ValueSubkeyRangeSet, VeilidUpdate};
 
 use crate::{
@@ -246,7 +246,7 @@ impl<P: Node> Actor for ShareResolver<P> {
                                 key: ch.key,
                                 prior_target: None
                             }).await {
-                                warn!("Failed to handle value change: {}", e);
+                                warn!(err = ?e, "watch value change");
                             }
                         }
                         VeilidUpdate::Shutdown => {
@@ -326,7 +326,7 @@ impl<P: Node> Actor for ShareResolver<P> {
 
         if let Some(valid_key) = resp.valid_key() {
             // Valid usable shares are watched.
-            info!("watch: share key {valid_key}");
+            trace!("watch: share key {valid_key}");
             self.watching.insert(*valid_key);
             self.node
                 .watch(*valid_key, ValueSubkeyRangeSet::single(0))

--- a/stigmerge/src/app.rs
+++ b/stigmerge/src/app.rs
@@ -79,10 +79,10 @@ impl App {
         let res = self.run_with_node(cancel, node.clone()).await;
         trace!("run_with_node completed");
         if let Err(e) = node.shutdown().await {
-            warn!("{e}");
+            warn!(err = ?e);
         }
         if let Err(e) = res {
-            error!("{e}");
+            error!(err = ?e);
             return Err(e);
         }
         Ok(())


### PR DESCRIPTION
Fetcher was also resetting on 120s disconnected, fixed.

Drive-by: cleaning up tracing crate usage and reducing log noise.