### PR TITLE
fix: recover lagged broadcast receiver

### DIFF
--- a/stigmerge-peer/src/actor.rs
+++ b/stigmerge-peer/src/actor.rs
@@ -12,7 +12,7 @@ use tracing::{error, info, instrument, trace, warn, Level};
 use veilid_core::VeilidUpdate;
 
 use crate::{
-    error::{CancelError, Result, Transient},
+    error::{is_lagged, CancelError, Result, Transient},
     is_cancelled, is_unrecoverable, Error, Node,
 };
 
@@ -348,6 +348,7 @@ impl<N: Node> WithVeilidConnection<N> {
                     return Err(CancelError.into())
                 }
                 res = self.update_rx.recv() => {
+                    if is_lagged(&res) { continue; }
                     let update = res?;
                     match update {
                         VeilidUpdate::Attachment(veilid_state_attachment) => {
@@ -455,6 +456,7 @@ impl<
                     }
                 }
                 res = self.update_rx.recv() => {
+                    if is_lagged(&res) { continue; }
                     let update = res?;
                     match update {
                         VeilidUpdate::Attachment(veilid_state_attachment) => {

--- a/stigmerge-peer/src/error.rs
+++ b/stigmerge-peer/src/error.rs
@@ -1,5 +1,6 @@
 use std::{fmt, io};
 
+use tokio::sync::broadcast;
 use veilid_core::VeilidAPIError;
 
 use crate::proto;
@@ -114,6 +115,13 @@ pub fn is_proto(e: &Error) -> bool {
 pub fn is_io(e: &Error) -> bool {
     match as_io(e) {
         Some(_) => true,
+        _ => false,
+    }
+}
+
+pub fn is_lagged<T>(result: &std::result::Result<T, broadcast::error::RecvError>) -> bool {
+    match result {
+        Err(broadcast::error::RecvError::Lagged(_)) => true,
         _ => false,
     }
 }

--- a/stigmerge-peer/src/have_resolver.rs
+++ b/stigmerge-peer/src/have_resolver.rs
@@ -8,7 +8,7 @@ use veilid_core::{TypedRecordKey, ValueSubkeyRangeSet, VeilidUpdate};
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
-    error::CancelError,
+    error::{is_lagged, CancelError},
     piece_map::PieceMap,
     Node, Result,
 };
@@ -153,6 +153,7 @@ impl<P: Node> Actor for HaveResolver<P> {
                     self.handle_request(req).await?;
                 }
                 res = update_rx.recv() => {
+                    if is_lagged(&res) { continue; }
                     let update = res.with_context(|| format!("have_resolver: receive veilid update"))?;
                     match update {
                         VeilidUpdate::ValueChange(ch) => {

--- a/stigmerge-peer/src/lib.rs
+++ b/stigmerge-peer/src/lib.rs
@@ -27,7 +27,7 @@ use tokio::sync::broadcast;
 use tracing::warn;
 use veilid_core::{RoutingContext, Sequencing, VeilidConfig, VeilidUpdate};
 
-pub use error::{is_cancelled, is_unrecoverable, CancelError, Error, Result};
+pub use error::{is_cancelled, is_lagged, is_unrecoverable, CancelError, Error, Result};
 pub use node::{Node, Veilid};
 
 #[cfg(test)]

--- a/stigmerge-peer/src/seeder.rs
+++ b/stigmerge-peer/src/seeder.rs
@@ -14,7 +14,7 @@ use veilid_core::VeilidUpdate;
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
-    error::{CancelError, Unrecoverable},
+    error::{is_lagged, CancelError, Unrecoverable},
     piece_map::PieceMap,
     proto::{self, BlockRequest, Decoder},
     types::{PieceState, ShareInfo},
@@ -121,6 +121,7 @@ impl<P: Node> Actor for Seeder<P> {
                     self.handle_request(req).await?;
                 }
                 res = self.verified_rx.recv() => {
+                    if is_lagged(&res) { continue; }
                     let piece_state = res.context(Unrecoverable::new("receive verified piece update"))?;
                     self.piece_map.set(piece_state.piece_index.try_into().unwrap());
                 }

--- a/stigmerge-peer/src/share_announcer.rs
+++ b/stigmerge-peer/src/share_announcer.rs
@@ -12,7 +12,7 @@ use veilid_core::{Target, TypedRecordKey, VeilidUpdate};
 
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
-    error::{CancelError, Unrecoverable},
+    error::{is_lagged, CancelError, Unrecoverable},
     proto::Header,
     Node, Result,
 };
@@ -147,6 +147,7 @@ impl<P: Node> Actor for ShareAnnouncer<P> {
                             self.handle_request(req).await?;
                         }
                         res = update_rx.recv() => {
+                            if is_lagged(&res) { continue; }
                             if let Target::PrivateRoute(ref route_id) = target {
                                 let update = res.with_context(|| format!("share_announcer: receive veilid update"))?;
                                 match update {

--- a/stigmerge-peer/src/share_resolver.rs
+++ b/stigmerge-peer/src/share_resolver.rs
@@ -10,7 +10,7 @@ use veilid_core::{Target, TypedRecordKey, ValueSubkeyRangeSet, VeilidUpdate};
 use crate::{
     actor::{Actor, Respondable, ResponseChannel},
     content_addressable::ContentAddressable,
-    error::{CancelError, Unrecoverable},
+    error::{is_lagged, CancelError, Unrecoverable},
     proto::{Digest, Header},
     Node, Result,
 };
@@ -233,6 +233,7 @@ impl<P: Node> Actor for ShareResolver<P> {
                     self.handle_request(req).await?;
                 }
                 res = update_rx.recv() => {
+                    if is_lagged(&res) { continue; }
                     let update = res.with_context(|| format!("share_resolver: receive veilid update"))?;
                     match update {
                         VeilidUpdate::ValueChange(ch) => {

--- a/stigmerge/src/app.rs
+++ b/stigmerge/src/app.rs
@@ -5,7 +5,7 @@ use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use stigmerge_peer::{
     actor::ConnectionState,
     fetcher::{self},
-    new_routing_context,
+    is_lagged, new_routing_context,
     node::{Node, Veilid},
     CancelError,
 };
@@ -166,6 +166,9 @@ impl App {
                         return Err(CancelError.into());
                     }
                     res = events.recv() => {
+                        if is_lagged(&res) {
+                            continue;
+                        }
                         let fetcher_status = match res? {
                             Event::FetcherStatus(status) => status,
                             _ => continue,
@@ -225,6 +228,7 @@ impl App {
                         return Err(CancelError.into());
                     }
                     res = events.recv() => {
+                        if is_lagged(&res) { continue; }
                         let (index_progress, verify_progress) = match res? {
                             Event::SeederLoading{ index_progress, verify_progress } => {
                                 (index_progress, verify_progress)
@@ -270,6 +274,7 @@ impl App {
                         return Err(CancelError.into());
                     }
                     res = events.recv() => {
+                        if is_lagged(&res) { continue; }
                         let share_info = match res? {
                             Event::ShareInfo(share_info) => share_info,
                             _ => continue,


### PR DESCRIPTION
In the event a broadcast receive errors, it could be due to lag. Larger buffers can help avoid lag, but some lag may be inevitable due to async scheduling -- imagine a Maxwell's demon that starves the receiver long enough for its buffer to fill.

This is a brute-force patch over the problem; it would be better to make auto-recovery endemic somehow to how all broadcast channels are used, but first let's see if this fixes long-term process instability.